### PR TITLE
Allow 100% in EnergySource

### DIFF
--- a/src/schemas/EnergySource.yaml
+++ b/src/schemas/EnergySource.yaml
@@ -19,5 +19,5 @@ properties:
   Percentage:
     type: integer
     description: Percentage of EnergyType being used by the charging stations
-    maximum: 99
+    maximum: 100
     minimum: 0


### PR DESCRIPTION
Not sure about that, but I believe that user should be able to set EnergySource to 100%